### PR TITLE
Make spotify link recognition more robust using regex.

### DIFF
--- a/src/twitch/twitch.service.ts
+++ b/src/twitch/twitch.service.ts
@@ -2,7 +2,7 @@ import { Client, ChatUserstate, client } from 'tmi.js';
 
 import SpotifyService from '../spotify/spotify.service';
 import Config from '../types/config';
-import { getTrackIdFromLink, SPOTIFY_LINK_START } from '../utils';
+import { getTrackIdFromLink, SPOTIFY_LINK_REGEX } from '../utils';
 
 interface TwitchOptions {
 	channels: string[];
@@ -89,7 +89,7 @@ export default class TwitchService {
 
 			console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
 			msg = msg.substring(`${this.config.COMMAND_PREFIX} `.length);
-			if (msg.startsWith(SPOTIFY_LINK_START)) {
+			if (SPOTIFY_LINK_REGEX.test(msg)) {
 				await this.handleSpotifyLink(msg, target);
 			} else {
 				console.log('Command used but no Spotify link provided');

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -1,4 +1,4 @@
-export const SPOTIFY_LINK_REGEX = /https:\/\/open\.spotify\.com(?:\/[-\w]+)*?\/track\/([\w]+)(?:\?.*)/;
+export const SPOTIFY_LINK_REGEX = /https:\/\/open\.spotify\.com(?:\/[-\w]+)*?\/track\/([\w]+)(?:\?.*)?/;
 
 export const getTrackIdFromLink = (link: string): string | null => {
 	try {

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -1,13 +1,10 @@
-export const SPOTIFY_LINK_START = 'https://open.spotify.com/track/';
+export const SPOTIFY_LINK_REGEX = /https:\/\/open\.spotify\.com(?:\/[-\w]+)*?\/track\/([\w]+)(?:\?.*)/;
 
 export const getTrackIdFromLink = (link: string): string | null => {
 	try {
-		const startOfId = SPOTIFY_LINK_START.length;
-		const endOfId = link.indexOf('?');
-		if (startOfId > 0 && endOfId > 0) {
-			return link.substring(startOfId, endOfId);
-		} else if (startOfId > 0 && endOfId === -1) {
-			return link.substring(startOfId);
+		let match = link.match(SPOTIFY_LINK_REGEX);
+		if (match !== null) {
+			return match[1];
 		} else {
 			throw Error('No track ID found in URL');
 		}


### PR DESCRIPTION
Changed the string based link recognition to a more robust regex based one.
This was motivated by some peoples spotify share links having additional paths before the track id.